### PR TITLE
Remove NotNull constraint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/Comment.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/Comment.java
@@ -25,7 +25,6 @@ public class Comment {
 
     @Getter
     @Setter
-    @NotNull
     @ManyToOne
     @JsonIgnore
     private Annotation annotation;

--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/Comment.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/Comment.java
@@ -6,7 +6,6 @@ import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Entity


### PR DESCRIPTION
When Jackson deserialises the JSON it won't populate this value so unless we want to add code in the Java to do it we should just take of the validation.