### PR TITLE
Add new note type for page notes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/AnnotationType.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/AnnotationType.java
@@ -5,7 +5,8 @@ public enum AnnotationType {
     HIGHLIGHT("highlight"),
     POINT("point"),
     STRIKEOUT("strikeout"),
-    TEXTBOX("textbox");
+    TEXTBOX("textbox"),
+    NOTE("note");
 
     private String type;
 

--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/AnnotationType.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/AnnotationType.java
@@ -6,7 +6,7 @@ public enum AnnotationType {
     POINT("point"),
     STRIKEOUT("strikeout"),
     TEXTBOX("textbox"),
-    PAGE_NOTE("pagenote");
+    PAGENOTE("pagenote");
 
     private String type;
 

--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/AnnotationType.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/AnnotationType.java
@@ -6,7 +6,7 @@ public enum AnnotationType {
     POINT("point"),
     STRIKEOUT("strikeout"),
     TEXTBOX("textbox"),
-    NOTE("note");
+    PAGE_NOTE("pagenote");
 
     private String type;
 


### PR DESCRIPTION
We need a new type that will be ignored by annotate.js but we can extract for page notes.