### PR TITLE
Make sure foriegn keys are populated

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/Annotation.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/Annotation.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.reform.em.annotation.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -18,10 +20,47 @@ import java.util.UUID;
 
 @Entity
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class Annotation {
+
+    public Annotation() {
+    }
+
+    public Annotation(UUID uuid, String createdBy,
+                      String lastModifiedBy,
+                      Date modifiedOn,
+                      Date createdOn,
+                      AnnotationSet annotationSet,
+                      AnnotationType type,
+                      long page,
+                      Set<Comment> comments,
+                      String colour,
+                      Long pointX,
+                      Long pointY,
+                      Long fontSize,
+                      Long height,
+                      Long width,
+                      List<Point> lines,
+                      Set<Rectangle> rectangles) {
+        this.uuid = uuid;
+        this.createdBy = createdBy;
+        this.lastModifiedBy = lastModifiedBy;
+        this.modifiedOn = modifiedOn;
+        this.createdOn = createdOn;
+        this.annotationSet = annotationSet;
+        this.type = type;
+        this.page = page;
+        this.colour = colour;
+        this.pointX = pointX;
+        this.pointY = pointY;
+        this.fontSize = fontSize;
+        this.height = height;
+        this.width = width;
+        this.lines = lines;
+        this.rectangles = rectangles;
+        setComments(comments);
+
+    }
 
     @Getter
     @Setter
@@ -68,8 +107,13 @@ public class Annotation {
     @NotNull
     private long page;
 
+    public final void setComments(Set<Comment> comments) {
+        if (this.comments != null) {
+            this.comments.forEach(comment -> comment.setAnnotation(this));
+        }
+    }
+
     @Getter
-    @Setter
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "annotation")
     private Set<Comment> comments;
 

--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/AnnotationSet.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/AnnotationSet.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.em.annotation.domain;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -16,10 +18,27 @@ import java.util.UUID;
 
 @Entity
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class AnnotationSet {
+
+    public AnnotationSet() {
+    }
+
+    public AnnotationSet(UUID uuid,
+                         String createdBy,
+                         String lastModifiedBy,
+                         Date modifiedOn,
+                         Date createdOn,
+                         String documentUri,
+                         Set<Annotation> annotations) {
+        this.uuid = uuid;
+        this.createdBy = createdBy;
+        this.lastModifiedBy = lastModifiedBy;
+        this.modifiedOn = modifiedOn;
+        this.createdOn = createdOn;
+        this.documentUri = documentUri;
+        setAnnotations(annotations);
+    }
 
     @Getter
     @Setter
@@ -55,8 +74,14 @@ public class AnnotationSet {
     @NotNull
     private String documentUri;
 
+    public final void setAnnotations(Set<Annotation> annotations) {
+        this.annotations = annotations;
+        if (this.annotations != null) {
+            this.annotations.forEach(annotation -> annotation.setAnnotationSet(this));
+        }
+    }
+
     @Getter
-    @Setter
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "annotationSet")
     private Set<Annotation> annotations;
 

--- a/src/test/java/uk/gov/hmcts/reform/em/annotation/controllers/StoredAnnotationSetControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/annotation/controllers/StoredAnnotationSetControllerTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.em.annotation.controllers;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
We need to set the relationship between `AnnotationSet`s and `Annotation`s and `Annotation`s and `Comment`s so that Hibernate populates the foreign keys.

This was all made harder by how Jackson and Lombok seem to work together with which constructor gets called in different situations.  