### PR TITLE
Ensure audit fields are populated

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/config/JpaConfig.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.reform.em.annotation.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAware",
+    dateTimeProviderRef = "dateTimeService")
+public class JpaConfig {
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/Annotation.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/Annotation.java
@@ -59,7 +59,6 @@ public class Annotation {
         this.lines = lines;
         this.rectangles = rectangles;
         setComments(comments);
-
     }
 
     @Getter
@@ -111,7 +110,8 @@ public class Annotation {
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "annotation")
     private Set<Comment> comments;
 
-    public final void setComments(Set<Comment> comments) {
+    public void setComments(Set<Comment> comments) {
+        this.comments = comments;
         if (this.comments != null) {
             this.comments.forEach(comment -> comment.setAnnotation(this));
         }

--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/audit/AuditorAwareImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/audit/AuditorAwareImpl.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.em.annotation.domain.audit;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.em.annotation.service.security.SecurityUtilService;
+
+@Service("auditorAware")
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    private SecurityUtilService securityUtilService;
+
+    @Autowired
+    public AuditorAwareImpl(SecurityUtilService securityUtilService) {
+        this.securityUtilService = securityUtilService;
+    }
+
+    @Override
+    public String getCurrentAuditor() {
+        return securityUtilService.getUserId();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/audit/CurrentDateTimeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/annotation/domain/audit/CurrentDateTimeService.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.em.annotation.domain.audit;
+
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.stereotype.Service;
+
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+@Service("dateTimeService")
+public class CurrentDateTimeService implements DateTimeProvider {
+
+    @Override
+    public Calendar getNow() {
+        return GregorianCalendar.from(ZonedDateTime.now());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/em/annotation/controllers/StoredAnnotationSetControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/annotation/controllers/StoredAnnotationSetControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.em.annotation.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,9 +29,11 @@ import uk.gov.hmcts.reform.em.annotation.componenttests.sugar.RestActions;
 
 import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 import static uk.gov.hmcts.reform.em.annotation.componenttests.Helper.*;
@@ -105,6 +108,19 @@ public class StoredAnnotationSetControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(GOOD_ANNOTATION_SET_MINIMUM_STR))
             .andExpect(status().isCreated());
+    }
+
+    @Test
+    public void postAnnotationSetOkWithAudit() throws Exception {
+        mvc.perform(post(ANNOTATION_SET_ENDPOINT)
+            .headers(headers)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(GOOD_ANNOTATION_SET_MINIMUM_STR))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.createdBy").value("user"))
+            .andExpect(jsonPath("$.lastModifiedBy").value("user"))
+            .andExpect(jsonPath("$.createdOn").value(notNullValue()))
+            .andExpect(jsonPath("$.modifiedOn").value(notNullValue()));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/em/annotation/controllers/StoredAnnotationSetControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/annotation/controllers/StoredAnnotationSetControllerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.em.annotation.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
Add configuration so that the audit fields are populated in the domain - fields such as createdBy, lastModifiedBy, modifiedOn, createdOn.