### PR TITLE
Do not overwrite createdBy or createdOn fields

### DIFF
--- a/application/src/main/java/uk/gov/hmcts/reform/em/annotation/service/AnnotationService.java
+++ b/application/src/main/java/uk/gov/hmcts/reform/em/annotation/service/AnnotationService.java
@@ -39,7 +39,8 @@ public class AnnotationService {
 
     public Annotation update(UUID uuid, Annotation annotation) {
         Annotation originalAnnotation = getById(uuid);
-        BeanUtils.copyProperties(annotation, originalAnnotation, "annotationSet", "uuid", "comments");
+        BeanUtils.copyProperties(annotation, originalAnnotation,
+            "annotationSet", "uuid", "comments", "createdBy", "createdOn");
         if (originalAnnotation.getComments() == null) {
             originalAnnotation.setComments(new HashSet<>());
         }

--- a/application/src/test/java/uk/gov/hmcts/reform/em/annotation/service/AnnotationServiceTest.java
+++ b/application/src/test/java/uk/gov/hmcts/reform/em/annotation/service/AnnotationServiceTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.em.annotation.domain.Annotation;
 import uk.gov.hmcts.reform.em.annotation.domain.Comment;
 import uk.gov.hmcts.reform.em.annotation.repository.AnnotationRepository;
 
+import java.util.Date;
 import java.util.HashSet;
 import java.util.UUID;
 
@@ -49,6 +50,28 @@ public class AnnotationServiceTest {
 
         assertThat(updatedAnnotation.getHeight(), equalTo(newAnnotation.getHeight()));
     }
+
+    @Test
+    public void should_update_an_annotation_without_clearing_audit_fields() {
+        Date createdOn = new Date();
+        String createdBy = "1";
+        Annotation originalAnnotation = Annotation.builder()
+            .height(100L)
+            .createdOn(createdOn)
+            .createdBy(createdBy)
+            .build();
+        Annotation newAnnotation = Annotation.builder()
+            .height(200L)
+            .build();
+
+        when(repository.findOne(ORIGINAL_UUID)).thenReturn(originalAnnotation);
+
+        Annotation updatedAnnotation = service.update(ORIGINAL_UUID, newAnnotation);
+
+        assertThat(updatedAnnotation.getCreatedBy(), equalTo(createdBy));
+        assertThat(updatedAnnotation.getCreatedOn(), equalTo(createdOn));
+    }
+
 
     @Test
     public void should_update_an_annotation_with_comment_without_comment() {


### PR DESCRIPTION
The audit fields were being wiped if the updated annotation from the front end didn't send up those fields. These should probably be immutable so I've added code to stop them being overwritten from the request.